### PR TITLE
Use sarif4k from analysis-dev GH packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,6 +45,8 @@ jobs:
             detekt.multiplatform.disabled=true
             disableRedundantTargets=true
             enabledExecutables=debug
+            gpr.user=${{ github.actor }}
+            gpr.key=${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload gradle reports
         if: ${{ always() }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -95,6 +95,8 @@ jobs:
             detekt.multiplatform.disabled=true
             disableRedundantTargets=true
             enabledExecutables=debug
+            gprUser=${{ github.actor }}
+            gprKey=${{ secrets.GITHUB_TOKEN }}
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,8 +45,8 @@ jobs:
             detekt.multiplatform.disabled=true
             disableRedundantTargets=true
             enabledExecutables=debug
-            gpr.user=${{ github.actor }}
-            gpr.key=${{ secrets.GITHUB_TOKEN }}
+            gprUser=${{ github.actor }}
+            gprKey=${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload gradle reports
         if: ${{ always() }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   detekt_check:
-    runs-on: ubuntu-20.04
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -20,11 +18,11 @@ jobs:
         with:
           java-version: 11
           distribution: zulu
-      - uses: burrunan/gradle-cache-action@v1
+      - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-          # additional files to calculate key for dependency cache
-          gradle-dependencies-cache-key: |
-            buildSrc/**/Versions.kt
-      - name: Run gradle command
-        run: ./gradlew detektAll --build-cache
+          arguments: |
+            detektAll
+            --build-cache
+            -PgprUser=${{ github.actor }}
+            -PgprKey=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           # release workflow should have access to all tags
           fetch-depth: 0
-          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: gradle release from tag
         # if workflow is triggered after push of a tag, deploy full release
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: ./gradlew --build-cache -Prelease linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
+        run: ./gradlew --build-cache -Prelease -PgprUser=${{ github.actor }} -PgprKey=${{ secrets.GITHUB_TOKEN }} linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
       - name: gradle snapshot from branch
         # if workflow is triggered after push to a branch, deploy snapshot
         if: ${{ startsWith(github.ref, 'refs/heads/') }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sarif4k"]
-	path = sarif4k
-	url = https://github.com/analysis-dev/sarif4k.git

--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ or using [PMD rules](https://pmd.github.io/). But in all cases a lot of time wil
 The project uses gradle as a build system and can be built with the command `./gradlew build`.
 To compile native artifacts, you will need to install prerequisites as described in Kotlin/Native documentation.
 
+To access dependencies hosted on Github Package Registry, you need to add the foolowing into `gradle.properties` or `~/.gradle/gradle.properties`:
+```properties
+gprUser=<GH username>
+gprKey=<GH personal access token>
+```
+Personal Access Token should be generated via https://github.com/settings/tokens/new with the scope at least containing `read:packages`.
+
 Because of generated code, you will need to run the build once to correctly import project in IDE with resolved imports.
 
 ## Contribution

--- a/save-plugins/warn-plugin/build.gradle.kts
+++ b/save-plugins/warn-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
             dependencies {
                 implementation(projects.saveCommon)
                 implementation(libs.kotlinx.serialization.core)
-                implementation("io.github.detekt.sarif4k:sarif4k")
+                implementation("io.github.detekt.sarif4k:sarif4k:0.1.0-SNAPSHOT")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,11 +7,22 @@ include("save-plugins:fix-plugin")
 include("save-plugins:warn-plugin")
 include("save-reporters")
 include("save-common-test")
-includeBuild("sarif4k")
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/analysis-dev/sarif4k")
+            val gprUser: String? by settings
+            val gprKey: String? by settings
+            credentials {
+                username = gprUser
+                password = gprKey
+            }
+            content {
+                includeGroup("io.github.detekt.sarif4k")
+            }
+        }
     }
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Instead of `includeBuild`, use artifacts published from https://github.com/analysis-dev/sarif4k/tree/feature/publishing to Github Package registry.
With this change developers will have to add additional properties to work with save-cli source code:
```properties
gprUser=<GH username>
gprKey=<GH personal access token>
```
Personal Access Token should be generated via https://github.com/settings/tokens/new with the scope at least containing `read:packages`.
This, however, is a temporary workaround, which should be more fast and stable than `includeBuild`